### PR TITLE
Fix icon not loading on Linux

### DIFF
--- a/guilib.py
+++ b/guilib.py
@@ -32,7 +32,10 @@ class MainApp(tk.Tk):
 		tk.Tk.__init__(self)
 		
 		self.title("Res14C")
-		self.iconbitmap("res14c.ico")
+		try:
+			self.iconbitmap("res14c.ico")
+		except tk.TclError as e:
+			pass
 		
 		frame = tk.Frame(self)
 		frame.pack(padx = 5, pady = 5)


### PR DESCRIPTION
Thanks for sharing your research code!

On Linux, the app doesn't start because it can't load the window icon ([because the `.ico` format only works on Windows, as far as I can tell](https://stackoverflow.com/questions/11176638/tkinter-tclerror-error-reading-bitmap-file?noredirect=1&lq=1)):

```
 python res14c.py 
Traceback (most recent call last):
  File "res14c.py", line 5, in <module>
    app = MainApp()
  File "/home/steko/Scaricati/Res14C/guilib.py", line 35, in __init__
    self.iconphoto(False, tk.PhotoImage(file="res14c.ico"))
  File "/usr/lib64/python3.8/tkinter/__init__.py", line 4061, in __init__
    Image.__init__(self, 'photo', name, cnf, master, **kw)
  File "/usr/lib64/python3.8/tkinter/__init__.py", line 4006, in __init__
    self.tk.call(('image', 'create', imgtype, name,) + options)
_tkinter.TclError: couldn't recognize data in image file "res14c.ico"
```

This change allows the program to continue if the icon cannot be loaded.