### PR TITLE
Explicit latin1 encoding for intcal13.14c

### DIFF
--- a/c14lib.py
+++ b/c14lib.py
@@ -7,8 +7,8 @@ def load_calibration_curve(fcalib):
 	# load calibration curve
 	# data from: fcalib 14c file
 	# returns: [[CalBP, ConvBP, CalSigma], ...], sorted by CalBP
-	
-	with open(fcalib, "r") as f:
+
+	with open(fcalib, "r", encoding="latin1") as f:
 		data = f.read()
 	data = data.split("\n")
 	cal_curve = []


### PR DESCRIPTION
Upon actually using the program, I found another platform-dependent bug, namely the character encoding of `intcal13.14c`, so I set it explicitly to latin1. I know because [I have the same parameter in iosacal](https://codeberg.org/steko/iosacal/src/commit/a25887783c250ec815d33fc7876a7607af33f347/iosacal/core.py#L97) :scientist: 

With that fixed, it works really well. The use of multiprocessing is very clever.